### PR TITLE
jekyll style posts, no date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+_site
+.sass-cache
+.jekyll-metadata
+.idea/*

--- a/404.html
+++ b/404.html
@@ -1,0 +1,5 @@
+---
+layout: default
+---
+
+404

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,14 @@
+source "https://rubygems.org"
+
+gem "jekyll"
+gem "minima"
+gem "webrick"
+# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
+# uncomment the line below. To upgrade, run `bundle update github-pages`.
+# gem "github-pages", group: :jekyll_plugins
+
+group :jekyll_plugins do
+  gem "jekyll-feed", "~> 0.6"
+end
+
+gem "kramdown-parser-gfm"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,79 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.4)
+      public_suffix (>= 2.0.2, < 6.0)
+    colorator (1.1.0)
+    concurrent-ruby (1.2.2)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.15.5)
+    forwardable-extended (2.6.0)
+    http_parser.rb (0.8.0)
+    i18n (1.13.0)
+      concurrent-ruby (~> 1.0)
+    jekyll (3.9.3)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (>= 0.7, < 2)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 2.0)
+      kramdown (>= 1.17, < 3)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (>= 1.7, < 4)
+      safe_yaml (~> 1.0)
+    jekyll-feed (0.15.1)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-sass-converter (1.5.2)
+      sass (~> 3.4)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    kramdown (2.3.2)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.8.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.3.6)
+    minima (2.5.1)
+      jekyll (>= 3.5, < 5.0)
+      jekyll-feed (~> 0.9)
+      jekyll-seo-tag (~> 2.1)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (4.0.7)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rexml (3.2.5)
+    rouge (3.26.0)
+    safe_yaml (1.0.5)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    webrick (1.8.1)
+
+PLATFORMS
+  arm64-darwin-20
+  x86_64-darwin-22
+
+DEPENDENCIES
+  jekyll
+  jekyll-feed (~> 0.6)
+  kramdown-parser-gfm
+  minima
+  webrick
+
+BUNDLED WITH
+   2.3.7

--- a/Vlists.md
+++ b/Vlists.md
@@ -1,1 +1,0 @@
-Todo copy https://github.com/ohAitch/vlist-rs readme here

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,5 @@
+markdown: kramdown
+theme: minima
+plugins:
+  - jekyll-feed
+

--- a/_plugins/no_date.rb
+++ b/_plugins/no_date.rb
@@ -1,0 +1,12 @@
+# https://stackoverflow.com/questions/27099427/jekyll-filename-without-date
+class Jekyll::PostReader
+  # Don't use DATE_FILENAME_MATCHER so we don't need to put those stupid dates
+  # in the filename. Also limit to just *.markdown, so it won't process binary
+  # files from e.g. drags.
+  def read_posts(dir)
+    read_publishable(dir, "_posts", /.*\.md$/)
+  end
+  def read_drafts(dir)
+    read_publishable(dir, "_drafts", /.*\.md$/)
+  end
+end

--- a/_posts/ChatOpsVCS.md
+++ b/_posts/ChatOpsVCS.md
@@ -1,3 +1,10 @@
+---
+layout: post
+title:  "ChatOpsVCS"
+date:   2023-05-10 10:22:14 -0700
+permalink: chatops-vcs
+---
+
 ## What if your whole codebase were a whole bunch of slack messages?
 
 ## Why?

--- a/_posts/ReverseWrangling.md
+++ b/_posts/ReverseWrangling.md
@@ -1,3 +1,10 @@
+---
+layout: post
+title:  "ReverseWrangling"
+date:   2023-05-10 10:22:14 -0700
+permalink: reverse-wrangling
+---
+
 ["High-performance Tree Wrangling, the APL Way"](https://www.youtube.com/watch?v=hzPd3umu78g) inspired exploration of reversing an s-expression
 <!-- ^ TODO embed -->
 

--- a/_posts/Vlists.md
+++ b/_posts/Vlists.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: "Vlists"
+date:   2023-05-10 10:22:14 -0700
+permalink: vlists
+---
+
+Todo copy https://github.com/ohAitch/vlist-rs readme here

--- a/_posts/saga.md
+++ b/_posts/saga.md
@@ -1,3 +1,11 @@
+---
+layout: post
+title:  "Saga"
+date:   2023-05-21 15:31:25 -0700
+categories: jekyll update
+permalink: saga
+---
+
 epic
 - flow / user journey snippet
 	- story == card

--- a/index.html
+++ b/index.html
@@ -1,7 +1,0 @@
-<ul>
-  {% for post in site.posts %}
-    <li>
-      <a href="{{ post.url }}">{{ post.title }}</a>
-    </li>
-  {% endfor %}
-</ul>

--- a/index.md
+++ b/index.md
@@ -1,0 +1,6 @@
+---
+# Feel free to add content and custom Front Matter to this file.
+# To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
+
+layout: home
+---


### PR DESCRIPTION
I started with `jekyll new ohno-blog --force` and fiddled a bit - see https://stackoverflow.com/questions/27099427/jekyll-filename-without-date

Theoretically it is correct to follow the gemfile instructions and use `# gem "github-pages", group: :jekyll_plugins` but then no posts show up on the index, but maybe it will Just Work if merged anyway?

to run locally
```
bundle
jekyll serve
```

<img width="769" alt="Screenshot 2023-05-21 at 5 05 22 PM" src="https://github.com/ohAitch/ohno-blog/assets/578159/b259566d-4e1d-4bfd-9c40-9705e037a302">
<img width="960" alt="Screenshot 2023-05-21 at 5 05 17 PM" src="https://github.com/ohAitch/ohno-blog/assets/578159/32718977-007a-499d-a258-0c1bced79ed2">
